### PR TITLE
Fix call to remove inside ascending for loop

### DIFF
--- a/src/edu/gatech/gtisc/jbirch/cftree/CFNode.java
+++ b/src/edu/gatech/gtisc/jbirch/cftree/CFNode.java
@@ -432,12 +432,15 @@ public class CFNode {
 	 * @param newE
 	 */
 	private void replaceClosestPairWithNewMergedEntry(CFEntryPair p, CFEntry newE) {
+
 		for(int i=0; i<this.entries.size(); i++) {
-			if(this.entries.get(i).equals(p.e1))
+			if(this.entries.get(i).equals(p.e1)) {
 				this.entries.set(i, newE);
-			
-			else if(this.entries.get(i).equals(p.e2))
+
+			} else if(this.entries.get(i).equals(p.e2)) {
 				this.entries.remove(i);
+				--i;
+			}
 		}
 	}
 	


### PR DESCRIPTION
"When List.remove() is called it will shrink the list. If this is done inside the ascending loop iterating through all elements it will skip the element after the removed index." https://rules.sonarsource.com/java/RSPEC-5413